### PR TITLE
Adding Virilis (Varlamore)

### DIFF
--- a/src/main/java/easyunnote/EasyUnnotePlugin.java
+++ b/src/main/java/easyunnote/EasyUnnotePlugin.java
@@ -51,6 +51,7 @@ public class EasyUnnotePlugin extends Plugin
 		"Cook",
 		"Butler",
 		"Demon butler",
+		"Virilis",
 	};
 
 	private static final String[] BANKNOTE_LIKE = {


### PR DESCRIPTION
Useful PC to unnote bones at The Teomat.  Addressing issue "Allow ability to use noted bones on "Virilis" NPC in Varlamore #9" on the main branch.
https://github.com/mad-s/easy-unnote/issues/9