### PR TITLE
Add Mercenary to list of NPC's that can un-note

### DIFF
--- a/src/main/java/easyunnote/EasyUnnotePlugin.java
+++ b/src/main/java/easyunnote/EasyUnnotePlugin.java
@@ -53,7 +53,8 @@ public class EasyUnnotePlugin extends Plugin {
 			"Wesley",
 			"Zahur",
 			"Friendly Forester",
-
+			"Mercenary",
+		
 			"Rick",
 			"Maid",
 			"Cook",


### PR DESCRIPTION
Added [Mercenary](https://oldschool.runescape.wiki/w/Mercenary_(Ferox_Enclave)) to the list of NPC's that can un-note items